### PR TITLE
fix(extension): Manage tops entirely within bundle extension

### DIFF
--- a/extension/util.js
+++ b/extension/util.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const async = require('async');
+
+module.exports.queryTops = function (streamtip, log, callback) {
+	const now = new Date();
+	/* eslint-disable camelcase */
+	async.parallel({
+		daily(cb) {
+			streamtip.api.getAllTips({
+				date_from: new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString(),
+				limit: 1,
+				sort_by: 'amount'
+			}, cb);
+		},
+		monthly(cb) {
+			streamtip.api.getAllTips({
+				date_from: new Date(now.getFullYear(), now.getMonth(), 1).toISOString(),
+				limit: 1,
+				sort_by: 'amount'
+			}, cb);
+		}
+	}, (err, results) => {
+		const ret = {daily: null, monthly: null};
+
+		if (err) {
+			log.warn('Unable to query tops from Streamtip!');
+			return callback(ret);
+		}
+
+		ret.daily = results.daily.length === 1 ? results.daily[0] : null;
+		ret.monthly = results.monthly.length === 1 ? results.monthly[0] : null;
+
+		callback(ret);
+	});
+	/* eslint-enable camelcase */
+};
+
+module.exports.compareTops = function (tip, tops) {
+	const ret = {monthly: null, daily: null};
+
+	Object.keys(tops).forEach(period => {
+		if (!tops[period] || tip.cents > tops[period].cents) {
+			ret[period] = tip;
+		}
+	});
+
+	return ret;
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "StreamTip integration",
   "license": "MIT",
   "dependencies": {
-    "streamtip-listener": "^1.3.3"
+    "async": "^1.5.2",
+    "streamtip": "^1.0.1"
   },
   "scripts": {
     "test": "npm run static",


### PR DESCRIPTION
This fixes an annoying issue of daily top being improperly overwritten by whatever the next tip is after a server restart, as streamtip-listener would not track that correctly.
Also attempts to query for daily top at startup, fiddly due to timezones though.
This also switches to a cleaner rewrite of the streamtip-listener library, which will be deprecated if this is accepted.
